### PR TITLE
iot-gate-imx8plus: Add aarch64 build option for container

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ root@5ea9a9133c3a:/usr/src/app# ./flash_iot.sh -d d1d8 -i /data/images/<balena-o
 ```
 
 By default the container image is built to run on x86 hosts. If you would like to build and run the container image on an armv7 device, please use `./run_container.sh -a armv7 ...`.
+The same, aarch64 devices can build and run the container by running `./run_container.sh -a aarch64 ...`. The `aarch64` configuration is reported to work from Ubuntu in Parallels on Apple M3 Sillicon.
 
 ### Support
 

--- a/run_container.sh
+++ b/run_container.sh
@@ -60,7 +60,11 @@ fi
 
 
 if [[ ${arch} = "armv7" ]]; then
+	log "Will build flash container for armv7..."
 	imageTag="--build-arg RT=armv7hf-ubuntu:focal-run-20221215"
+elif [[ ${arch} = "aarch64" ]]; then
+	log "Will build flash container for aarch64..."
+	imageTag="--build-arg RT=aarch64-ubuntu:focal-run-20221215"
 fi
 
 # Build Dockerfile, if image does not exist already


### PR DESCRIPTION
This allows using the flash tools on Apple M3 laptops or RPi4s
Change-type: patch